### PR TITLE
recognize .hd64 opcode as z180

### DIFF
--- a/gas/config/tc-z80.c
+++ b/gas/config/tc-z80.c
@@ -3458,6 +3458,7 @@ const pseudo_typeS md_pseudo_table[] =
   { ".r800", set_inss, INS_R800},
   { ".set", s_set, 0},
   { ".z180", set_inss, INS_Z180},
+  { ".hd64", set_inss, INS_Z180},
   { ".z80", set_inss, INS_Z80},
   { ".z80n", set_inss, INS_Z80N},
   { "db" , emit_data, 1},


### PR DESCRIPTION
sdcc 4.0 snapshot is emitting .hd64 instead of .z180 for -mz180